### PR TITLE
scripts: add checks for google analytics tracking

### DIFF
--- a/scripts/easytracker-check.sh
+++ b/scripts/easytracker-check.sh
@@ -1,0 +1,18 @@
+!#/bin/bash
+
+for activity in app/src/main/java/com/profsys/*/activity/*.java
+do
+if grep "EasyTracker.getInstance(this).activityStart(this);" $activity; then
+echo OK
+else
+echo $activity MISSING EASYTRACKING IN ACTIVITYSTART
+fi
+
+
+if grep "EasyTracker.getInstance(this).activityStop(this);" $activity; then
+echo OK
+else
+echo $activity MISSING EASYTRACKING IN ACTIVITYSTOP
+fi
+
+done

--- a/scripts/profsys-graddle.bash
+++ b/scripts/profsys-graddle.bash
@@ -39,6 +39,12 @@ configure() {
     echo "error: staging or release not allowed with dirty changes!";
     exit
   fi
+
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  if $DIR/easytracker-check.sh | grep MISSING; then
+    echo "error: some activities do not have google analytics properly enabled!";
+    exit
+  fi
 }
 
 pre_install() {


### PR DESCRIPTION
Some activities were not properly tracked. This test should detect that before
any new release.

Related-to: #106 (NewsDetailActivity does not seem to have the google analytics tracker enabled.)